### PR TITLE
fix(database): enable foreign key support for sqlite connections

### DIFF
--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -61,7 +61,8 @@ func NewPgSqlDatabase(config Config, gConfig *gorm.Config) *gorm.DB {
 }
 
 func NewSqliteDatabase(config Config, gConfig *gorm.Config) *gorm.DB {
-	db, err := gorm.Open(sqlite.Open(config.Database), gConfig)
+	dsn := fmt.Sprintf("%s?_foreign_keys=1", config.Database)
+	db, err := gorm.Open(sqlite.Open(dsn), gConfig)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Previously, SQLite connections did not explicitly enable foreign key constraints, which are disabled by default in SQLite. This change updates the DSN generation to include `?_foreign_keys=1` when connecting to SQLite databases.