### PR TITLE
fix(module): align module path with v2 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ A production-ready Go library providing modular, composable infrastructure compo
 ### Installation
 
 ```bash
-go get github.com/chan-jui-huang/go-backend-package
+go get github.com/chan-jui-huang/go-backend-package/v2
 ```
 
 ### Basic Usage
@@ -45,8 +45,8 @@ go get github.com/chan-jui-huang/go-backend-package
 package main
 
 import (
-    "github.com/chan-jui-huang/go-backend-package/pkg/booter"
-    "github.com/chan-jui-huang/go-backend-package/pkg/database"
+    "github.com/chan-jui-huang/go-backend-package/v2/pkg/booter"
+    "github.com/chan-jui-huang/go-backend-package/v2/pkg/database"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/chan-jui-huang/go-backend-package
+module github.com/chan-jui-huang/go-backend-package/v2
 
 go 1.25.7
 

--- a/pkg/booter/booter.go
+++ b/pkg/booter/booter.go
@@ -6,7 +6,7 @@ import (
 	"path"
 	"strings"
 
-	"github.com/chan-jui-huang/go-backend-package/pkg/booter/config"
+	"github.com/chan-jui-huang/go-backend-package/v2/pkg/booter/config"
 	"github.com/spf13/viper"
 )
 

--- a/pkg/pagination/pagination_test.go
+++ b/pkg/pagination/pagination_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/chan-jui-huang/go-backend-package/pkg/pagination"
+	"github.com/chan-jui-huang/go-backend-package/v2/pkg/pagination"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 )


### PR DESCRIPTION
- update the module declaration to github.com/chan-jui-huang/go-backend-package/v2
- switch internal package imports and tests to the v2 module path
- revise README installation and usage examples to use the semantic import path