### PR TITLE
test: move package tests to external test packages

### DIFF
--- a/pkg/argon2/argon2_test.go
+++ b/pkg/argon2/argon2_test.go
@@ -1,4 +1,4 @@
-package argon2
+package argon2_test
 
 import (
 	"encoding/base64"
@@ -7,9 +7,9 @@ import (
 	"testing"
 	"time"
 
-	argon2lib "golang.org/x/crypto/argon2"
-
+	argon2pkg "github.com/chan-jui-huang/go-backend-package/v2/pkg/argon2"
 	"github.com/stretchr/testify/require"
+	argon2lib "golang.org/x/crypto/argon2"
 )
 
 func TestMakeAndVerifyTableDriven(t *testing.T) {
@@ -25,18 +25,18 @@ func TestMakeAndVerifyTableDriven(t *testing.T) {
 	for _, tc := range cases {
 		c := tc // copy for safety
 		t.Run(c.name, func(t *testing.T) {
-			hash := MakeArgon2IdHash(c.password)
+			hash := argon2pkg.MakeArgon2IdHash(c.password)
 			require.NotEmpty(t, hash)
 			// correct password verifies
-			require.True(t, VerifyArgon2IdHash(c.password, hash))
+			require.True(t, argon2pkg.VerifyArgon2IdHash(c.password, hash))
 			// wrong password does not verify
-			require.False(t, VerifyArgon2IdHash(c.password+"x", hash))
+			require.False(t, argon2pkg.VerifyArgon2IdHash(c.password+"x", hash))
 		})
 	}
 }
 
 func TestMakeArgon2IdHashWithConfigPHCString(t *testing.T) {
-	cfg := &Argon2IdConfig{
+	cfg := &argon2pkg.Argon2IdConfig{
 		Memory:  32 * 1024,
 		Time:    1,
 		Threads: 1,
@@ -44,7 +44,7 @@ func TestMakeArgon2IdHashWithConfigPHCString(t *testing.T) {
 		SaltLen: 8,
 	}
 	password := "phc-test"
-	hash := MakeArgon2IdHashWithConfig(password, cfg)
+	hash := argon2pkg.MakeArgon2IdHashWithConfig(password, cfg)
 	require.NotEmpty(t, hash)
 
 	// PHC string: $argon2id$v=19$m=...,t=...,p=...$<salt>$<hash>
@@ -76,26 +76,26 @@ func TestMakeArgon2IdHashWithConfigPHCString(t *testing.T) {
 	require.Equal(t, int(cfg.KeyLen), len(outHash))
 
 	// verify should succeed
-	require.True(t, VerifyArgon2IdHash(password, hash))
+	require.True(t, argon2pkg.VerifyArgon2IdHash(password, hash))
 }
 
 func TestVerifyArgon2IdHashConstantTimeLike(t *testing.T) {
 	// Use a small but realistic config to keep test fast
-	cfg := &Argon2IdConfig{Memory: 32 * 1024, Time: 1, Threads: 1, KeyLen: 16, SaltLen: 8}
+	cfg := &argon2pkg.Argon2IdConfig{Memory: 32 * 1024, Time: 1, Threads: 1, KeyLen: 16, SaltLen: 8}
 	password := "timing-test"
-	hash := MakeArgon2IdHashWithConfig(password, cfg)
-	require.True(t, VerifyArgon2IdHash(password, hash))
+	hash := argon2pkg.MakeArgon2IdHashWithConfig(password, cfg)
+	require.True(t, argon2pkg.VerifyArgon2IdHash(password, hash))
 
 	iters := 50
 	var durGood time.Duration
 	var durBad time.Duration
 	for i := 0; i < iters; i++ {
 		s := time.Now()
-		VerifyArgon2IdHash(password, hash)
+		argon2pkg.VerifyArgon2IdHash(password, hash)
 		durGood += time.Since(s)
 
 		s = time.Now()
-		VerifyArgon2IdHash(password+"x", hash)
+		argon2pkg.VerifyArgon2IdHash(password+"x", hash)
 		durBad += time.Since(s)
 	}
 	avgGood := durGood / time.Duration(iters)

--- a/pkg/authentication/authenticator_test.go
+++ b/pkg/authentication/authenticator_test.go
@@ -1,4 +1,4 @@
-package authentication
+package authentication_test
 
 import (
 	"crypto/ed25519"
@@ -7,20 +7,21 @@ import (
 	"testing"
 	"time"
 
+	authentication "github.com/chan-jui-huang/go-backend-package/v2/pkg/authentication"
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/stretchr/testify/require"
 )
 
 func mustB64Key(b []byte) string { return base64.RawURLEncoding.EncodeToString(b) }
 
-func newAuthFromKeys(pub ed25519.PublicKey, priv ed25519.PrivateKey, accessLife time.Duration) (*Authenticator, error) {
-	cfg := Config{
+func newAuthFromKeys(pub ed25519.PublicKey, priv ed25519.PrivateKey, accessLife time.Duration) (*authentication.Authenticator, error) {
+	cfg := authentication.Config{
 		PrivateKey:           mustB64Key(priv),
 		PublicKey:            mustB64Key(pub),
 		AccessTokenLifeTime:  accessLife,
 		RefreshTokenLifeTime: time.Hour,
 	}
-	return NewAuthenticator(cfg)
+	return authentication.NewAuthenticator(cfg)
 }
 
 func TestIssueAndVerifyJwt(t *testing.T) {

--- a/pkg/booter/booter_test.go
+++ b/pkg/booter/booter_test.go
@@ -1,14 +1,16 @@
-package booter
+package booter_test
 
 import (
 	"flag"
 	"os"
 	"path/filepath"
 	"testing"
+
+	booter "github.com/chan-jui-huang/go-backend-package/v2/pkg/booter"
 )
 
 func TestNewConfig(t *testing.T) {
-	cfg := NewConfig("/tmp/project", "custom.yml", true)
+	cfg := booter.NewConfig("/tmp/project", "custom.yml", true)
 
 	if cfg.RootDir != "/tmp/project" {
 		t.Fatalf("expected RootDir to be /tmp/project, got %s", cfg.RootDir)
@@ -27,7 +29,7 @@ func TestNewDefaultConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cfg := NewDefaultConfig()
+	cfg := booter.NewDefaultConfig()
 
 	if cfg.RootDir != wd {
 		t.Fatalf("expected RootDir to be %s, got %s", wd, cfg.RootDir)
@@ -61,7 +63,7 @@ func TestNewConfigWithCommand(t *testing.T) {
 		"-debug=true",
 	}
 
-	cfg := NewConfigWithCommand()
+	cfg := booter.NewConfigWithCommand()
 
 	if cfg.RootDir != "/tmp/cli-project" {
 		t.Fatalf("expected RootDir to be /tmp/cli-project, got %s", cfg.RootDir)
@@ -76,7 +78,7 @@ func TestNewConfigWithCommand(t *testing.T) {
 	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 	os.Args = []string{"cmd"}
 
-	defaultCfg := NewConfigWithCommand()
+	defaultCfg := booter.NewConfigWithCommand()
 
 	if defaultCfg.RootDir != wd {
 		t.Fatalf("expected default RootDir to be %s, got %s", wd, defaultCfg.RootDir)
@@ -99,8 +101,8 @@ func TestBootConfigLoaderEnvExpansion(t *testing.T) {
 	os.Setenv("MY_HOST", "localhost")
 	defer os.Unsetenv("MY_HOST")
 
-	bc := NewConfig(tmp, "config.yml", false)
-	loader := BootConfigLoader(bc)
+	bc := booter.NewConfig(tmp, "config.yml", false)
+	loader := booter.BootConfigLoader(bc)
 
 	type databaseConfig struct {
 		Host string `mapstructure:"host"`
@@ -120,7 +122,7 @@ func TestBootConfigLoaderPanicWhenFileNotFound(t *testing.T) {
 		}
 	}()
 
-	BootConfigLoader(NewConfig(t.TempDir(), "missing.yml", false))
+	booter.BootConfigLoader(booter.NewConfig(t.TempDir(), "missing.yml", false))
 }
 
 func TestBootConfigLoaderPanicWhenYamlInvalid(t *testing.T) {
@@ -135,5 +137,5 @@ func TestBootConfigLoaderPanicWhenYamlInvalid(t *testing.T) {
 		}
 	}()
 
-	BootConfigLoader(NewConfig(tmp, "config.yml", false))
+	booter.BootConfigLoader(booter.NewConfig(tmp, "config.yml", false))
 }

--- a/pkg/booter/config/loader_test.go
+++ b/pkg/booter/config/loader_test.go
@@ -1,21 +1,22 @@
-package config
+package config_test
 
 import (
 	"testing"
 
+	config "github.com/chan-jui-huang/go-backend-package/v2/pkg/booter/config"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 )
 
-type testConfig struct {
-	Name string `mapstructure:"name"`
-}
-
 func TestNew(t *testing.T) {
+	type testConfig struct {
+		Name string `mapstructure:"name"`
+	}
+
 	v := viper.New()
 	v.Set("service.name", "alpha")
 
-	r := New(v)
+	r := config.New(v)
 	cfg := &testConfig{}
 	r.Unmarshal("service", cfg)
 
@@ -23,8 +24,12 @@ func TestNew(t *testing.T) {
 }
 
 func TestLoaderUnmarshal(t *testing.T) {
+	type testConfig struct {
+		Name string `mapstructure:"name"`
+	}
+
 	v := viper.New()
-	r := New(v)
+	r := config.New(v)
 
 	v.Set("reg.name", "beta")
 	cfg := &testConfig{}
@@ -34,11 +39,15 @@ func TestLoaderUnmarshal(t *testing.T) {
 }
 
 func TestLoaderUnmarshalMany(t *testing.T) {
+	type testConfig struct {
+		Name string `mapstructure:"name"`
+	}
+
 	v := viper.New()
 	v.Set("a.name", "one")
 	v.Set("b.name", "two")
 
-	r := New(v)
+	r := config.New(v)
 
 	cfgA := &testConfig{}
 	cfgB := &testConfig{}

--- a/pkg/clickhouse/clickhouse_test.go
+++ b/pkg/clickhouse/clickhouse_test.go
@@ -1,12 +1,14 @@
-package clickhouse
+package clickhouse_test
 
 import (
 	"reflect"
 	"testing"
+
+	clickhouse "github.com/chan-jui-huang/go-backend-package/v2/pkg/clickhouse"
 )
 
 func TestConfigFields(t *testing.T) {
-	var c Config
+	var c clickhouse.Config
 	typ := reflect.TypeOf(c)
 	expected := []string{"Addr", "Database", "Username", "Password", "MaxOpenConns", "MaxIdleConns"}
 	for _, name := range expected {

--- a/pkg/database/database_test.go
+++ b/pkg/database/database_test.go
@@ -1,21 +1,22 @@
-package database
+package database_test
 
 import (
 	"testing"
 	"time"
 
+	database "github.com/chan-jui-huang/go-backend-package/v2/pkg/database"
 	"gorm.io/gorm/logger"
 )
 
 func TestGetDriverValidAndInvalid(t *testing.T) {
 	// valid
-	if got := GetDriver(MySql); got != MySql {
+	if got := database.GetDriver(database.MySql); got != database.MySql {
 		t.Fatalf("expected MySql, got %v", got)
 	}
-	if got := GetDriver(PgSql); got != PgSql {
+	if got := database.GetDriver(database.PgSql); got != database.PgSql {
 		t.Fatalf("expected PgSql, got %v", got)
 	}
-	if got := GetDriver(Sqlite); got != Sqlite {
+	if got := database.GetDriver(database.Sqlite); got != database.Sqlite {
 		t.Fatalf("expected Sqlite, got %v", got)
 	}
 
@@ -26,39 +27,39 @@ func TestGetDriverValidAndInvalid(t *testing.T) {
 		}
 	}()
 	// This should panic
-	GetDriver(Driver("invalid"))
+	database.GetDriver(database.Driver("invalid"))
 }
 
 func TestGetGormLogLevelMapping(t *testing.T) {
-	if lvl := GetGormLogLevel(Info); lvl != logger.Info {
+	if lvl := database.GetGormLogLevel(database.Info); lvl != logger.Info {
 		t.Fatalf("expected logger.Info, got %v", lvl)
 	}
-	if lvl := GetGormLogLevel(Warn); lvl != logger.Warn {
+	if lvl := database.GetGormLogLevel(database.Warn); lvl != logger.Warn {
 		t.Fatalf("expected logger.Warn, got %v", lvl)
 	}
-	if lvl := GetGormLogLevel(Error); lvl != logger.Error {
+	if lvl := database.GetGormLogLevel(database.Error); lvl != logger.Error {
 		t.Fatalf("expected logger.Error, got %v", lvl)
 	}
-	if lvl := GetGormLogLevel(Silent); lvl != logger.Silent {
+	if lvl := database.GetGormLogLevel(database.Silent); lvl != logger.Silent {
 		t.Fatalf("expected logger.Silent, got %v", lvl)
 	}
 	// default
-	if lvl := GetGormLogLevel(LogLevel("unknown")); lvl != logger.Info {
+	if lvl := database.GetGormLogLevel(database.LogLevel("unknown")); lvl != logger.Info {
 		t.Fatalf("expected default logger.Info, got %v", lvl)
 	}
 }
 
 func TestNewSqliteConfigAppliedAndPool(t *testing.T) {
-	cfg := Config{
-		Driver:          Sqlite,
+	cfg := database.Config{
+		Driver:          database.Sqlite,
 		Database:        "file::memory:",
 		MaxOpenConns:    5,
 		MaxIdleConns:    2,
 		ConnMaxLifetime: time.Minute,
-		LogLevel:        Warn,
+		LogLevel:        database.Warn,
 	}
 
-	db := New(cfg)
+	db := database.New(cfg)
 	if db == nil {
 		t.Fatalf("expected non-nil db")
 	}
@@ -117,5 +118,5 @@ func TestNewInvalidDriverPanics(t *testing.T) {
 			t.Fatalf("expected panic for invalid driver in New")
 		}
 	}()
-	New(Config{Driver: Driver("invalid")})
+	database.New(database.Config{Driver: database.Driver("invalid")})
 }

--- a/pkg/decoder/decoder_test.go
+++ b/pkg/decoder/decoder_test.go
@@ -1,8 +1,10 @@
-package decoder
+package decoder_test
 
 import (
 	"testing"
 	"time"
+
+	decoder "github.com/chan-jui-huang/go-backend-package/v2/pkg/decoder"
 )
 
 func TestDecode(t *testing.T) {
@@ -19,7 +21,7 @@ func TestDecode(t *testing.T) {
 	}
 
 	var cfg testConfig
-	err := Decode(input, &cfg)
+	err := decoder.Decode(input, &cfg)
 	if err != nil {
 		t.Fatalf("Decode() error = %v", err)
 	}
@@ -46,7 +48,7 @@ func TestDecodeInvalidTime(t *testing.T) {
 	}
 
 	var cfg testConfig
-	err := Decode(input, &cfg)
+	err := decoder.Decode(input, &cfg)
 	if err == nil {
 		t.Fatal("Decode() error = nil, want non-nil")
 	}

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -1,4 +1,4 @@
-package logger
+package logger_test
 
 import (
 	"io/ioutil"
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	logger "github.com/chan-jui-huang/go-backend-package/v2/pkg/logger"
 	"go.uber.org/zap/zapcore"
 )
 
@@ -18,8 +19,8 @@ func TestNewConsoleLoggerEncoders(t *testing.T) {
 		encoder    zapcore.Encoder
 		wantSubstr string
 	}{
-		{"json", JsonEncoder, "\"message\""},
-		{"console", ConsoleEncoder, "hello-console"},
+		{"json", logger.JsonEncoder, "\"message\""},
+		{"console", logger.ConsoleEncoder, "hello-console"},
 	}
 
 	for _, tt := range tests {
@@ -34,18 +35,18 @@ func TestNewConsoleLoggerEncoders(t *testing.T) {
 			os.Stdout = tmpfile
 			defer func() { os.Stdout = orig }()
 
-			cfg := Config{Type: Console, Level: Info}
-			logger, err := NewLogger(cfg, tt.encoder)
+			cfg := logger.Config{Type: logger.Console, Level: logger.Info}
+			loggerInstance, err := logger.NewLogger(cfg, tt.encoder)
 			if err != nil {
 				t.Fatal(err)
 			}
-			defer logger.Sync()
+			defer loggerInstance.Sync()
 
 			// write a message
 			if tt.name == "json" {
-				logger.Info("hello-json")
+				loggerInstance.Info("hello-json")
 			} else {
-				logger.Info("hello-console")
+				loggerInstance.Info("hello-console")
 			}
 
 			// ensure writes flushed
@@ -72,22 +73,22 @@ func TestNewFileLoggerWritesFile(t *testing.T) {
 	defer os.RemoveAll(tmpdir)
 
 	logPath := filepath.Join(tmpdir, "test.log")
-	cfg := Config{
-		Type:       File,
+	cfg := logger.Config{
+		Type:       logger.File,
 		LogPath:    logPath,
 		MaxSize:    1024,
 		MaxBackups: 1,
 		MaxAge:     time.Hour,
 		Compress:   false,
-		Level:      Info,
+		Level:      logger.Info,
 	}
-	logger, err := NewLogger(cfg, JsonEncoder)
+	loggerInstance, err := logger.NewLogger(cfg, logger.JsonEncoder)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer logger.Sync()
+	defer loggerInstance.Sync()
 
-	logger.Info("file-log-message")
+	loggerInstance.Info("file-log-message")
 	// give some time for write
 	time.Sleep(10 * time.Millisecond)
 
@@ -101,14 +102,14 @@ func TestNewFileLoggerWritesFile(t *testing.T) {
 }
 
 func TestSamplingApplied(t *testing.T) {
-	cfg := Config{Type: Console, Level: Info}
+	cfg := logger.Config{Type: logger.Console, Level: logger.Info}
 	// no sampler
-	loggerNoSampler := NewConsoleLogger(cfg, JsonEncoder)
+	loggerNoSampler := logger.NewConsoleLogger(cfg, logger.JsonEncoder)
 	defer loggerNoSampler.Sync()
 	coreNo := reflect.TypeOf(loggerNoSampler.Core()).String()
 
 	// with sampler
-	loggerWithSampler, err := NewLogger(cfg, JsonEncoder, DefaultZapOptions...)
+	loggerWithSampler, err := logger.NewLogger(cfg, logger.JsonEncoder, logger.DefaultZapOptions...)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/random/random_test.go
+++ b/pkg/random/random_test.go
@@ -1,9 +1,11 @@
-package random
+package random_test
 
 import (
 	"regexp"
 	"strconv"
 	"testing"
+
+	random "github.com/chan-jui-huang/go-backend-package/v2/pkg/random"
 )
 
 func TestRandomStringLengthAndCharset(t *testing.T) {
@@ -16,7 +18,7 @@ func TestRandomStringLengthAndCharset(t *testing.T) {
 		n := n
 		t.Run(strconv.Itoa(n), func(t *testing.T) {
 			t.Parallel()
-			s := RandomString(n)
+			s := random.RandomString(n)
 			if len(s) != n {
 				t.Fatalf("RandomString(%d) length = %d, want %d", n, len(s), n)
 			}
@@ -35,7 +37,7 @@ func TestRandomStringUniqueness(t *testing.T) {
 	seen := make(map[string]struct{}, runs)
 
 	for i := 0; i < runs; i++ {
-		s := RandomString(n)
+		s := random.RandomString(n)
 		if len(s) != n {
 			t.Fatalf("RandomString(%d) length = %d, want %d", n, len(s), n)
 		}

--- a/pkg/redis/redis_test.go
+++ b/pkg/redis/redis_test.go
@@ -1,27 +1,28 @@
-package redis
+package redis_test
 
 import (
 	"testing"
 	"time"
 
+	redis "github.com/chan-jui-huang/go-backend-package/v2/pkg/redis"
 	"github.com/stretchr/testify/require"
 )
 
 func TestNewReturnsClient(t *testing.T) {
-	cfg := Config{Address: "127.0.0.1:6379"}
-	c := New(cfg)
+	cfg := redis.Config{Address: "127.0.0.1:6379"}
+	c := redis.New(cfg)
 	require.NotNil(t, c)
 }
 
 func TestNewClientOptions(t *testing.T) {
-	cfg := Config{
+	cfg := redis.Config{
 		Address:         "localhost:6379",
 		Password:        "secret",
 		DB:              2,
 		MinIdleConns:    5,
 		ConnMaxLifetime: 30 * time.Second,
 	}
-	c := New(cfg)
+	c := redis.New(cfg)
 	opts := c.Options()
 
 	require.Equal(t, cfg.Address, opts.Addr)
@@ -32,8 +33,8 @@ func TestNewClientOptions(t *testing.T) {
 }
 
 func TestNewClientZeroValues(t *testing.T) {
-	cfg := Config{Address: "redis.example:1234"}
-	c := New(cfg)
+	cfg := redis.Config{Address: "redis.example:1234"}
+	c := redis.New(cfg)
 	opts := c.Options()
 
 	require.Equal(t, cfg.Address, opts.Addr)

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -1,9 +1,11 @@
-package scheduler
+package scheduler_test
 
 import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	scheduler "github.com/chan-jui-huang/go-backend-package/v2/pkg/scheduler"
 )
 
 type dummyJob struct {
@@ -15,48 +17,53 @@ func (j *dummyJob) GetFrequency() string { return j.freq }
 func (j *dummyJob) Execute()             { atomic.AddInt32(&j.executed, 1) }
 
 func TestBacklogJobsAndStart(t *testing.T) {
-	s := NewScheduler(map[string]Job{})
+	s := scheduler.NewScheduler(map[string]scheduler.Job{})
 	dj := &dummyJob{freq: "*/1 * * * * *"}
-	s.BacklogJobs(map[string]Job{"job1": dj})
-	if _, ok := s.backlogJobs["job1"]; !ok {
-		t.Fatalf("backlog not set")
-	}
-
-	// Start should add backlog jobs to crontab and clear backlog
+	s.BacklogJobs(map[string]scheduler.Job{"job1": dj})
 	s.Start()
 	defer s.Stop()
-	if len(s.backlogJobs) != 0 {
-		t.Fatalf("backlog not cleared after Start")
-	}
-	if _, ok := s.jobs["job1"]; !ok {
-		t.Fatalf("job not added on Start")
+
+	deadline := time.Now().Add(1500 * time.Millisecond)
+	for atomic.LoadInt32(&dj.executed) == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("expected backlog job to run after Start")
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 }
 
 func TestAddAndRemoveJob(t *testing.T) {
-	s := NewScheduler(map[string]Job{})
+	s := scheduler.NewScheduler(map[string]scheduler.Job{})
 	dj := &dummyJob{freq: "*/1 * * * * *"}
 	if err := s.AddJob("j1", dj); err != nil {
 		t.Fatalf("AddJob error: %v", err)
 	}
-	if _, ok := s.jobs["j1"]; !ok {
-		t.Fatalf("job not present after AddJob")
+
+	s.Start()
+	deadline := time.Now().Add(1500 * time.Millisecond)
+	for atomic.LoadInt32(&dj.executed) == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("expected added job to run")
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 
+	executedBeforeRemove := atomic.LoadInt32(&dj.executed)
 	s.RemoveJob("j1")
-	if _, ok := s.jobs["j1"]; ok {
-		t.Fatalf("job still present after RemoveJob")
+	time.Sleep(1100 * time.Millisecond)
+	executedAfterRemove := atomic.LoadInt32(&dj.executed)
+	s.Stop()
+
+	if executedAfterRemove != executedBeforeRemove {
+		t.Fatalf("expected removed job not to run again, got before=%d after=%d", executedBeforeRemove, executedAfterRemove)
 	}
 }
 
 func TestStopReturnsContext(t *testing.T) {
-	s := NewScheduler(map[string]Job{})
+	s := scheduler.NewScheduler(map[string]scheduler.Job{})
 	dj := &dummyJob{freq: "*/1 * * * * *"}
-	if err := s.AddJob("j2", dj); err != nil {
-		t.Fatalf("AddJob error: %v", err)
-	}
-	// start the underlying cron to ensure Stop behaves
-	s.crontab.Start()
+	s.BacklogJobs(map[string]scheduler.Job{"j2": dj})
+	s.Start()
 	ctx := s.Stop()
 	if ctx == nil {
 		t.Fatalf("Stop returned nil context")

--- a/pkg/stacktrace/stacktrace_test.go
+++ b/pkg/stacktrace/stacktrace_test.go
@@ -1,13 +1,14 @@
-package stacktrace
+package stacktrace_test
 
 import (
 	"testing"
 
+	stacktrace "github.com/chan-jui-huang/go-backend-package/v2/pkg/stacktrace"
 	"github.com/pkg/errors"
 )
 
 func TestGetStackStraceNil(t *testing.T) {
-	st := GetStackStrace(nil)
+	st := stacktrace.GetStackStrace(nil)
 	if len(st) != 0 {
 		t.Fatalf("expected empty slice for nil error, got %v", st)
 	}
@@ -16,7 +17,7 @@ func TestGetStackStraceNil(t *testing.T) {
 func TestGetStackStraceWrappedError(t *testing.T) {
 	base := errors.New("boom")
 	wrapped := errors.Wrap(base, "wrapped")
-	st := GetStackStrace(wrapped)
+	st := stacktrace.GetStackStrace(wrapped)
 	if len(st) == 0 {
 		t.Fatalf("expected stack frames for wrapped error, got none")
 	}


### PR DESCRIPTION
Rename package-level tests to use xxx_test package names across the repository so they exercise the public API instead of package-private symbols by default.

Update test imports and references to call exported functions and construct exported types from the package under test.

Rewrite the scheduler tests to validate observable behavior through public methods rather than reading unexported internal state, while keeping the existing coverage for job registration, execution, and shutdown semantics.