### PR TITLE
Add keyed SHA256 hasher with configurable secret key

### DIFF
--- a/pkg/hash/hasher.go
+++ b/pkg/hash/hasher.go
@@ -1,0 +1,28 @@
+package hash
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+)
+
+type Config struct {
+	Key string
+}
+
+type Hasher struct {
+	key []byte
+}
+
+func NewHasher(config Config) *Hasher {
+	return &Hasher{
+		key: []byte(config.Key),
+	}
+}
+
+func (hasher *Hasher) MakeHash(value string) string {
+	hash := hmac.New(sha256.New, hasher.key)
+	_, _ = hash.Write([]byte(value))
+
+	return hex.EncodeToString(hash.Sum(nil))
+}


### PR DESCRIPTION
Introduce a hash package with a configurable keyed hasher. Adds a constructor that stores the secret key and a generic method for producing hex-encoded HMAC-SHA256 hashes.