### PR TITLE
Refactor job lifecycle API and update scheduler documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,15 +112,15 @@ Cron job scheduling with second-level precision via robfig/cron/v3.
 
 **Architecture**:
 - Global singleton: `Scheduler` instance initialized in `init()`
-- `Job` interface: `GetFrequency() string` (cron expression), `Execute()` (logic)
-- Backlog pattern: Queue jobs before scheduler starts
-- Lifecycle: `BacklogJobs()` → `Start()` → schedules all → `Stop()` returns context for shutdown
+- `Job` interface: `Name() string`, `CronExpression() string` (cron expression), `Execute()` (logic)
+- Queue pattern: Queue jobs before scheduler starts
+- Lifecycle: `QueueJobs()` → `Start()` → schedules all → `Stop()` returns context for shutdown
 
 **Methods**:
-- `BacklogJobs(map[string]Job)`: Queue jobs before start
+- `QueueJobs([]Job)`: Queue jobs before start
 - `Start()`: Schedules backlog, begins cron execution
-- `AddJob(key, job)`: Add job after start
-- `RemoveJob(key)`: Remove scheduled job
+- `ScheduleJob(job)`: Schedule job after start
+- `UnscheduleJob(key)`: Remove scheduled job
 - `Stop()`: Return shutdown context
 
 ---
@@ -395,10 +395,11 @@ _ = auth
 ```go
 type MyJob struct{}
 
-func (j *MyJob) GetFrequency() string { return "*/5 * * * *" } // Every 5 min
+func (j *MyJob) Name() string { return "myjob" }
+func (j *MyJob) CronExpression() string { return "*/5 * * * *" } // Every 5 min
 func (j *MyJob) Execute() { /* job logic */ }
 
-scheduler.Scheduler.BacklogJobs(map[string]scheduler.Job{"myjob": &MyJob{}})
+scheduler.Scheduler.QueueJobs([]scheduler.Job{&MyJob{}})
 scheduler.Scheduler.Start()
 ```
 

--- a/README.md
+++ b/README.md
@@ -248,9 +248,9 @@ _ = auth
 ### Schedule Jobs
 
 ```go
-scheduler.Scheduler.BacklogJobs(map[string]scheduler.Job{
-    "cleanup": &CleanupJob{},
-    "sync":    &SyncJob{},
+scheduler.Scheduler.QueueJobs([]scheduler.Job{
+    &CleanupJob{},
+    &SyncJob{},
 })
 
 scheduler.Scheduler.Start()

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -7,68 +7,78 @@ import (
 )
 
 type Job interface {
-	GetFrequency() string
+	Name() string
+	CronExpression() string
 	Execute()
 }
 
 type scheduler struct {
-	crontab     *cron.Cron
-	backlogJobs map[string]Job
-	jobs        map[string]cron.EntryID
+	crontab    *cron.Cron
+	queuedJobs map[string]Job
+	jobs       map[string]cron.EntryID
 }
 
 var Scheduler *scheduler
 
 func init() {
-	Scheduler = NewScheduler(map[string]Job{})
+	Scheduler = NewScheduler(nil)
 }
 
-func NewScheduler(backlogJobs map[string]Job) *scheduler {
+func NewScheduler(jobs []Job) *scheduler {
 	return &scheduler{
-		crontab:     cron.New(cron.WithSeconds()),
-		backlogJobs: backlogJobs,
-		jobs:        map[string]cron.EntryID{},
+		crontab:    cron.New(cron.WithSeconds()),
+		queuedJobs: newQueuedJobs(jobs),
+		jobs:       map[string]cron.EntryID{},
 	}
 }
 
-func (s *scheduler) BacklogJobs(backlogJobs map[string]Job) {
-	for name, backlogJob := range backlogJobs {
-		s.backlogJobs[name] = backlogJob
+func newQueuedJobs(jobs []Job) map[string]Job {
+	queuedJobs := map[string]Job{}
+	for _, job := range jobs {
+		queuedJobs[job.Name()] = job
+	}
+
+	return queuedJobs
+}
+
+func (s *scheduler) QueueJobs(jobs []Job) {
+	for _, job := range jobs {
+		s.queuedJobs[job.Name()] = job
 	}
 }
 
-func (s *scheduler) RemoveJobs(backlogJobs []string) {
-	for _, name := range backlogJobs {
-		delete(s.backlogJobs, name)
+func (s *scheduler) RemoveQueuedJobs(names []string) {
+	for _, name := range names {
+		delete(s.queuedJobs, name)
 	}
 }
 
-func (s *scheduler) ClearBacklogJobs() {
-	s.backlogJobs = map[string]Job{}
+func (s *scheduler) ClearQueuedJobs() {
+	s.queuedJobs = map[string]Job{}
 }
 
-func (s *scheduler) AddJob(name string, job Job) error {
-	id, err := s.crontab.AddFunc(job.GetFrequency(), job.Execute)
+func (s *scheduler) ScheduleJob(job Job) error {
+	id, err := s.crontab.AddFunc(job.CronExpression(), job.Execute)
 	if err != nil {
 		return err
 	}
-	s.jobs[name] = id
+	s.jobs[job.Name()] = id
 
 	return nil
 }
 
-func (s *scheduler) RemoveJob(name string) {
+func (s *scheduler) UnscheduleJob(name string) {
 	s.crontab.Remove(s.jobs[name])
 	delete(s.jobs, name)
 }
 
 func (s *scheduler) Start() {
-	for name, backlogJob := range s.backlogJobs {
-		if err := s.AddJob(name, backlogJob); err != nil {
+	for _, job := range s.queuedJobs {
+		if err := s.ScheduleJob(job); err != nil {
 			panic(err)
 		}
 	}
-	s.backlogJobs = map[string]Job{}
+	s.queuedJobs = map[string]Job{}
 	s.crontab.Start()
 }
 

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -9,17 +9,19 @@ import (
 )
 
 type dummyJob struct {
-	freq     string
-	executed int32
+	name           string
+	cronExpression string
+	executed       int32
 }
 
-func (j *dummyJob) GetFrequency() string { return j.freq }
-func (j *dummyJob) Execute()             { atomic.AddInt32(&j.executed, 1) }
+func (j *dummyJob) Name() string           { return j.name }
+func (j *dummyJob) CronExpression() string { return j.cronExpression }
+func (j *dummyJob) Execute()               { atomic.AddInt32(&j.executed, 1) }
 
-func TestBacklogJobsAndStart(t *testing.T) {
-	s := scheduler.NewScheduler(map[string]scheduler.Job{})
-	dj := &dummyJob{freq: "*/1 * * * * *"}
-	s.BacklogJobs(map[string]scheduler.Job{"job1": dj})
+func TestQueueJobsAndStart(t *testing.T) {
+	s := scheduler.NewScheduler(nil)
+	dj := &dummyJob{name: "job1", cronExpression: "*/1 * * * * *"}
+	s.QueueJobs([]scheduler.Job{dj})
 	s.Start()
 	defer s.Stop()
 
@@ -32,11 +34,11 @@ func TestBacklogJobsAndStart(t *testing.T) {
 	}
 }
 
-func TestAddAndRemoveJob(t *testing.T) {
-	s := scheduler.NewScheduler(map[string]scheduler.Job{})
-	dj := &dummyJob{freq: "*/1 * * * * *"}
-	if err := s.AddJob("j1", dj); err != nil {
-		t.Fatalf("AddJob error: %v", err)
+func TestScheduleAndUnscheduleJob(t *testing.T) {
+	s := scheduler.NewScheduler(nil)
+	dj := &dummyJob{name: "j1", cronExpression: "*/1 * * * * *"}
+	if err := s.ScheduleJob(dj); err != nil {
+		t.Fatalf("ScheduleJob error: %v", err)
 	}
 
 	s.Start()
@@ -49,7 +51,7 @@ func TestAddAndRemoveJob(t *testing.T) {
 	}
 
 	executedBeforeRemove := atomic.LoadInt32(&dj.executed)
-	s.RemoveJob("j1")
+	s.UnscheduleJob("j1")
 	time.Sleep(1100 * time.Millisecond)
 	executedAfterRemove := atomic.LoadInt32(&dj.executed)
 	s.Stop()
@@ -60,9 +62,9 @@ func TestAddAndRemoveJob(t *testing.T) {
 }
 
 func TestStopReturnsContext(t *testing.T) {
-	s := scheduler.NewScheduler(map[string]scheduler.Job{})
-	dj := &dummyJob{freq: "*/1 * * * * *"}
-	s.BacklogJobs(map[string]scheduler.Job{"j2": dj})
+	s := scheduler.NewScheduler(nil)
+	dj := &dummyJob{name: "j2", cronExpression: "*/1 * * * * *"}
+	s.QueueJobs([]scheduler.Job{dj})
 	s.Start()
 	ctx := s.Stop()
 	if ctx == nil {


### PR DESCRIPTION
- replace map-based backlog registration with queue-based job registration
- require jobs to expose Name and CronExpression methods
- rename active cron operations to ScheduleJob and UnscheduleJob
- update scheduler tests and documentation for the new lifecycle naming